### PR TITLE
Easy way to link groups

### DIFF
--- a/wat_bridge/wa.py
+++ b/wat_bridge/wa.py
@@ -35,7 +35,7 @@ from yowsup.layers.protocol_receipts.protocolentities import OutgoingReceiptProt
 from yowsup.layers.protocol_acks.protocolentities import OutgoingAckProtocolEntity
 from yowsup.stacks import YowStackBuilder
 
-from wat_bridge.static import SETTINGS, SIGNAL_TG, get_logger
+from wat_bridge.static import SETTINGS, SIGNAL_TG, SIGNAL_WA, get_logger
 from wat_bridge.helper import is_blacklisted
 
 logger = get_logger('wa')
@@ -80,6 +80,10 @@ class WaLayer(YowInterfaceLayer):
 
         # body = "<" + oidtotg + ">: " + message.getBody()
         body = message.getBody()
+
+        if body == '/getID':
+             self.send_msg(phone=sender, contact='TGWhatAppBot', message=sender)
+             return
 
         participant = message.getParticipant()
 

--- a/wat_bridge/wa.py
+++ b/wat_bridge/wa.py
@@ -102,7 +102,8 @@ class WaLayer(YowInterfaceLayer):
             entity.getFrom()
         )
 
-        self.toLower(ack)
+        #self.toLower(ack)
+        self.toLower(entity.ack())
 
     def send_msg(self, **kwargs):
         """Send a message.


### PR DESCRIPTION
In WhatsApp group with TGWhatAppBot, simply send `/getID` to get the group ID. Then pass that ID to `/link` command in group which has the `@TGWhatApp` Telegram bot.

In WhatsApp group, send :
```
/getID
```
will give `90XXXXXXXXX-XXXXXXXX`

In Telegram group, send :

```
/link 90XXXXXXXXX-XXXXXXXX
```
and the two groups will be bridged.